### PR TITLE
A couple of fixes

### DIFF
--- a/jsons/Beliefs.json
+++ b/jsons/Beliefs.json
@@ -3,7 +3,7 @@
 		"name": "Nature Worship",
 		"type": "Pantheon",
 		"uniques": [
-			"[+1 Faith] from every [Food Source]"
+			"[+1 Faith] from every [Food source]"
 		]
 	},
 	{

--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -662,6 +662,7 @@
 		"requiredTech": "Engineering",
 		"uniques": [
 			"Provides [1] [Power] <for every [Green Energy]>",
+			"Only available <with [Green Energy]>",
 			"Cost increases by [30] per owned city"
 		]
 	},


### PR DESCRIPTION
- Green Energy Transformer, as noted in the Discord, shouldn't be allowed to show up in the build list unless the player has obtained Green Energy.
- While the Pantheon belief here is overpowered, it also currently doesn't function. The reason it doesn't function: "Source" being capitalized when the tiles with the filtering unique it checks for don't capitalize it (case sensitivity strikes again).